### PR TITLE
Bugfix/1 mountpoint options

### DIFF
--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -8,6 +8,8 @@
     - role: ansible-role-autofs
       autofs_maps:
         - mountpoint: /bind
+          options:
+            - "--timeout=60"
           directories:
             - path: mount
               server: ":/mnt"

--- a/templates/template.autofs.j2
+++ b/templates/template.autofs.j2
@@ -1,2 +1,2 @@
 {{ ansible_managed | comment }}
-{{ item.mountpoint }} /etc/auto.{{ item.mountpoint | regex_replace('/', '') }}
+{{ item.mountpoint }} /etc/auto.{{ item.mountpoint | regex_replace('/', '') }} {% if item.options is defined %}{% for option in item.options %}{{ option }}{% if not loop.last %} {% endif %}{% endfor %} {% endif %}


### PR DESCRIPTION
Related to issue #1. 

Include the `options` specified for the `mountpoint` in the template but only when there are defined. Also, add this case to the molecule scenario.