### PR TITLE
Replace slashes in file names with character based on variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,8 @@
 # defaults file for autofs
 
 # The first slash in a path will be removed, all remaining slashes will be replaced with this character.
+#   Example: mountpoint=/bin/mount & slash_replace_char="-"
+#   Output file name: /etc/auto.bind-mount (leading slash removed, remaining replaced with "-")
 slash_replace_char: ""
 
 # Here you can configure automount mountpoints.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,9 @@
 ---
 # defaults file for autofs
 
+# The first slash in a path will be removed, all remaining slashes will be replaced with this character.
+slash_replace_char: ""
+
 # Here you can configure automount mountpoints.
 # autofs_maps:
 #   - mountpoint: /home

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,11 +44,11 @@
     - name: place autofs in /etc/auto.master.d/
       template:
         src: template.autofs.j2
-        dest: /etc/auto.master.d/00-{{ item.mountpoint | regex_replace('/', '') }}.autofs
+        dest: /etc/auto.master.d/00-{{ item.mountpoint | regex_replace('^/', '') | regex_replace('/', slash_replace_char) }}.autofs
         mode: "0640"
       loop: "{{ autofs_maps }}"
       loop_control:
-        label: /etc/auto.master.d/00-{{ item.mountpoint | regex_replace('/', '') }}.autofs
+        label: /etc/auto.master.d/00-{{ item.mountpoint | regex_replace('^/', '') | regex_replace('/', slash_replace_char) }}.autofs
       notify:
         - reload autofs
       when:
@@ -57,7 +57,7 @@
     - name: configure map
       template:
         src: map.j2
-        dest: /etc/auto.{{ item.mountpoint | regex_replace('/', '') }}
+        dest: /etc/auto.{{ item.mountpoint | regex_replace('^/', '') | regex_replace('/', slash_replace_char) }}
         mode: "0644"
       loop: "{{ autofs_maps }}"
       loop_control:
@@ -67,11 +67,11 @@
 
     - name: cleanup autofs file that should not exist
       file:
-        path: /etc/auto.master.d/00-{{ item.mountpoint | regex_replace('/', '') }}.autofs
+        path: /etc/auto.master.d/00-{{ item.mountpoint | regex_replace('^/', '') | regex_replace('/', slash_replace_char) }}.autofs
         state: absent
       loop: "{{ autofs_maps }}"
       loop_control:
-        label: /etc/auto.master.d/00-{{ item.mountpoint | regex_replace('/', '') }}.autofs
+        label: /etc/auto.master.d/00-{{ item.mountpoint | regex_replace('^/', '') | regex_replace('/', slash_replace_char) }}.autofs
       notify:
         - reload autofs
       when:
@@ -80,11 +80,11 @@
 
     - name: cleanup maps that should not exist
       file:
-        path: /etc/auto.{{ item.mountpoint | regex_replace('/', '') }}
+        path: /etc/auto.{{ item.mountpoint | regex_replace('^/', '') | regex_replace('/', slash_replace_char) }}
         state: absent
       loop: "{{ autofs_maps }}"
       loop_control:
-        label: "/etc/auto.{{ item.mountpoint | regex_replace('/', '') }}"
+        label: "/etc/auto.{{ item.mountpoint | regex_replace('^/', '') | regex_replace('/', slash_replace_char) }}"
       when:
         - item.state is defined
         - item.state == "absent"


### PR DESCRIPTION
Relates to issue #3.

Use the `slash_replace_char` to use as a replacement for slashes in file names. Always remove the leading slash. Default to removing the slashes (i.e. replacing with "") to maintain backwards compatibility. 