### PR TITLE
Resolve issue caused by pull request #4 and improve molecule test

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,6 +3,20 @@
   hosts: all
   become: yes
   gather_facts: yes
+  vars_files:
+    - vars.yml
 
   roles:
     - role: ansible-role-autofs
+      autofs_maps:
+        - mountpoint: "{{ mountpoint }}"
+          options:
+            - "--timeout 60"
+          directories:
+            - path: "{{ path }}"
+              server: ":/mnt"
+              options:
+                - "fstype=bind"
+        - mountpoint: /do_not_exist
+          state: absent
+      nis_master_map: auto.master

--- a/molecule/default/vars.yml
+++ b/molecule/default/vars.yml
@@ -1,0 +1,3 @@
+---
+mountpoint: /bind/mnt
+path: mount

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -3,26 +3,13 @@
   hosts: all
   become: yes
   gather_facts: yes
-
-  roles:
-    - role: ansible-role-autofs
-      autofs_maps:
-        - mountpoint: /bind
-          options:
-            - "--timeout=60"
-          directories:
-            - path: mount
-              server: ":/mnt"
-              options:
-                - "fstype=bind"
-        - mountpoint: /do_not_exist
-          state: absent
-      nis_master_map: auto.master
+  vars_files:
+    - vars.yml
 
   tasks:
-    - name: check /bind
+    - name: check that the path is available at the mountpoint
       stat:
-        path: /bind
+        path: "{{ mountpoint }}/{{ path }}"
       register: autofs_test_bind
       failed_when:
         - not autofs_test_bind.stat.exists

--- a/templates/template.autofs.j2
+++ b/templates/template.autofs.j2
@@ -1,2 +1,2 @@
 {{ ansible_managed | comment }}
-{{ item.mountpoint }} /etc/auto.{{ item.mountpoint | regex_replace('/', '') }} {% if item.options is defined %}{% for option in item.options %}{{ option }}{% if not loop.last %} {% endif %}{% endfor %} {% endif %}
+{{ item.mountpoint }} /etc/auto.{{ item.mountpoint | regex_replace('^/', '') | regex_replace('/', slash_replace_char) }} {% if item.options is defined %}{% for option in item.options %}{{ option }}{% if not loop.last %} {% endif %}{% endfor %} {% endif %}


### PR DESCRIPTION
Resolving bug caused by pull request #4 by updating the missed `regex_replace` filter to the new format required by the feature introduced in issue #3. Sorry for missing this initially.

Improve the molecule testing by changing the following:
1. Moving the role execution to the `converge` step in the default scenario.
    - This allows the role to fully complete (including flushing the handlers). Previously when the role execution was in the verify step, the autofs daemon did not get reloaded before the check task (since the handlers are not run until all tasks in a play are completed).
    - This also brings the scenario in-line with the standard approach outlined in the [molecule documentation](https://molecule.readthedocs.io/en/latest/getting-started.html#the-scenario-layout).
 2. Move the `mountpoint` and `path` variables for the scenario to a separate file.
     - This allows the variables to be reused across different steps in the molecule scenario (e.g. converge and verify).
 3. Set the verify task to check the `path` within the `mountpoint`, instead of the `mountpoint`.
     - The `mountpoint` will always be present even if the autofs configuration isn't correct since the role creates it. The true test for it the autofs mount is working is if the path is present (since that it was get's mounted by autofs).