### PR TITLE
Add optional name for map & Ignore folder creation for direct maps

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,7 +24,8 @@ slash_replace_char: ""
 #           - rsize=8192
 #           - wsize=8192
 #         server: "server.example.com:/"
-#   - mountpoint: /cifs
+#   - name: cifs-mounts  # optionally name the map (for use in files names).
+#     mountpoint: /cifs
 #     directories:
 #       - path: data
 #         options:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -15,7 +15,8 @@
               server: ":/mnt"
               options:
                 - "fstype=bind"
-        - mountpoint: /-
+        - name: direct-mounts
+          mountpoint: /-
           options:
             - "--timeout 60"
             - "--ghost"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -15,6 +15,15 @@
               server: ":/mnt"
               options:
                 - "fstype=bind"
+        - mountpoint: /-
+          options:
+            - "--timeout 60"
+            - "--ghost"
+          directories:
+            - path: /bind/direct/mount
+              server: ":/mnt"
+              options:
+                - "fstype=bind"
         - mountpoint: /do_not_exist
           state: absent
       nis_master_map: auto.master

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -7,7 +7,10 @@
   tasks:
     - name: check that the path is available at the mountpoint
       stat:
-        path: /bind/mnt/mount
+        path: "{{ item }}"
       register: autofs_test_bind
       failed_when:
         - not autofs_test_bind.stat.exists
+      loop:
+        - /bind/mnt/mount
+        - /bind/direct/mount

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -31,6 +31,19 @@
     - autofs_maps is defined
     - item.state is undefined or (item.state is defined and item.state == "present")
 
+- name: test if item name in autofs_maps is set correctly
+  assert:
+    that:
+      - item.name is string
+      - item.name is regex("^[A-Za-z0-9-_.^]+$")
+    quiet: yes
+  loop: "{{ autofs_maps }}"
+  loop_control:
+    label: "{{ item.mountpoint }}"
+  when:
+    - autofs_maps is defined
+    - item.name is defined
+
 - name: test if item in autofs_maps is set correctly
   assert:
     that:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,11 +44,11 @@
     - name: place autofs in /etc/auto.master.d/
       template:
         src: template.autofs.j2
-        dest: /etc/auto.master.d/00-{{ item.mountpoint | regex_replace('^/', '') | regex_replace('/', slash_replace_char) }}.autofs
+        dest: /etc/auto.master.d/00-{{ item.name | default(item.mountpoint) | regex_replace('^/', '') | regex_replace('/', slash_replace_char) }}.autofs
         mode: "0640"
       loop: "{{ autofs_maps }}"
       loop_control:
-        label: /etc/auto.master.d/00-{{ item.mountpoint | regex_replace('^/', '') | regex_replace('/', slash_replace_char) }}.autofs
+        label: /etc/auto.master.d/00-{{ item.name | default(item.mountpoint) | regex_replace('^/', '') | regex_replace('/', slash_replace_char) }}.autofs
       notify:
         - reload autofs
       when:
@@ -57,7 +57,7 @@
     - name: configure map
       template:
         src: map.j2
-        dest: /etc/auto.{{ item.mountpoint | regex_replace('^/', '') | regex_replace('/', slash_replace_char) }}
+        dest: /etc/auto.{{ item.name | default(item.mountpoint) | regex_replace('^/', '') | regex_replace('/', slash_replace_char) }}
         mode: "0644"
       loop: "{{ autofs_maps }}"
       loop_control:
@@ -67,11 +67,11 @@
 
     - name: cleanup autofs file that should not exist
       file:
-        path: /etc/auto.master.d/00-{{ item.mountpoint | regex_replace('^/', '') | regex_replace('/', slash_replace_char) }}.autofs
+        path: /etc/auto.master.d/00-{{ item.name | default(item.mountpoint) | regex_replace('^/', '') | regex_replace('/', slash_replace_char) }}.autofs
         state: absent
       loop: "{{ autofs_maps }}"
       loop_control:
-        label: /etc/auto.master.d/00-{{ item.mountpoint | regex_replace('^/', '') | regex_replace('/', slash_replace_char) }}.autofs
+        label: /etc/auto.master.d/00-{{ item.name | default(item.mountpoint) | regex_replace('^/', '') | regex_replace('/', slash_replace_char) }}.autofs
       notify:
         - reload autofs
       when:
@@ -80,11 +80,11 @@
 
     - name: cleanup maps that should not exist
       file:
-        path: /etc/auto.{{ item.mountpoint | regex_replace('^/', '') | regex_replace('/', slash_replace_char) }}
+        path: /etc/auto.{{ item.name | default(item.mountpoint) | regex_replace('^/', '') | regex_replace('/', slash_replace_char) }}
         state: absent
       loop: "{{ autofs_maps }}"
       loop_control:
-        label: "/etc/auto.{{ item.mountpoint | regex_replace('^/', '') | regex_replace('/', slash_replace_char) }}"
+        label: "/etc/auto.{{ item.name | default(item.mountpoint) | regex_replace('^/', '') | regex_replace('/', slash_replace_char) }}"
       when:
         - item.state is defined
         - item.state == "absent"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -101,6 +101,7 @@
         label: "{{ item.mountpoint }}"
       when:
         - item.state is not defined or (item.state is defined and item.state == "present")
+        - item.mountpoint != "/-"
   when:
     - autofs_maps is defined
 

--- a/templates/template.autofs.j2
+++ b/templates/template.autofs.j2
@@ -1,2 +1,2 @@
 {{ ansible_managed | comment }}
-{{ item.mountpoint }} /etc/auto.{{ item.mountpoint | regex_replace('^/', '') | regex_replace('/', slash_replace_char) }} {% if item.options is defined %}{% for option in item.options %}{{ option }}{% if not loop.last %} {% endif %}{% endfor %} {% endif %}
+{{ item.mountpoint }} /etc/auto.{{ item.name | default(item.mountpoint) | regex_replace('^/', '') | regex_replace('/', slash_replace_char) }} {% if item.options is defined %}{% for option in item.options %}{{ option }}{% if not loop.last %} {% endif %}{% endfor %} {% endif %}


### PR DESCRIPTION
Related to issue #6.

- Do not create a folder if the `mountpoint` is `/-` (i.e. if it's a direct map).
- Add optional `name` key to autofs maps for use in file names.
- Add a direct map to the molecule default scenario.