### PR TITLE
fix: reload autofs when changing mountpoint

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -62,6 +62,8 @@
       loop: "{{ autofs_maps }}"
       loop_control:
         label: "{{ item.mountpoint }}"
+      notify:
+        - Reload autofs
       when:
         - item.state is not defined or (item.state is defined and item.state == "present")
 


### PR DESCRIPTION
This commit fixes a bug where the service is not reloaded when the mount point configuration is changed.

Hi Robert,

Since the change seems to be pretty straightforward, I didn't take the time to do all the tests and the ansible-generator stuff.

Let me know what you think.

By the way, thanks for your work. I'm using this role on a set of 50 VMs spread into four Docker clusters.