### PR TITLE
Add option to keep autofs stopped

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,8 @@
 #   Output file name: /etc/auto.bind-mount (leading slash removed, remaining replaced with "-")
 slash_replace_char: ""
 
+autofs_service_state: "started"
+
 # Here you can configure automount mountpoints.
 # autofs_maps:
 #   - mountpoint: /home

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,8 +5,10 @@
   ansible.builtin.service:
     name: "{{ autofs_service }}"
     state: restarted
+  when: autofs_service_state != 'stopped'
 
 - name: Reload autofs
   ansible.builtin.service:
     name: "{{ autofs_service }}"
     state: reloaded
+  when: autofs_service_state != 'stopped'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -111,5 +111,5 @@
 - name: Start autofs
   ansible.builtin.service:
     name: "{{ autofs_service }}"
-    state: started
+    state: "{{ autofs_service_state }}"
     enabled: yes


### PR DESCRIPTION
We are using the role to prepare node images for warewulf. The images reside in containers. We can't start the autofs immediately.

Please consider incorporating our changes.

 \- Simppa -