### PR TITLE
Add support for builtin -hosts and -null maps

### DIFF
--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -23,6 +23,17 @@
       - item.mountpoint is defined
       - item.mountpoint is string
       - item.mountpoint is not none
+    quiet: yes
+  loop: "{{ autofs_maps }}"
+  loop_control:
+    label: "{{ item.mountpoint }}"
+  when:
+    - autofs_maps is defined
+    - item.state is undefined or (item.state is defined and item.state == "present")
+
+- name: assert | Test directories defined when not using builtin map
+  ansible.builtin.assert:
+    that:
       - item.directories is defined
       - item.directories is iterable
     quiet: yes
@@ -32,6 +43,7 @@
   when:
     - autofs_maps is defined
     - item.state is undefined or (item.state is defined and item.state == "present")
+    - item.options is defined and ("-hosts" not in item.options and "-null" not in item.options)
 
 - name: assert | Test item name in autofs_maps
   ansible.builtin.assert:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -68,7 +68,8 @@
       notify:
         - Reload autofs
       when:
-        - item.state is not defined or (item.state is defined and item.state == "present")
+        - (item.state is not defined or (item.state is defined and item.state == "present"))
+        - item.options is defined and ("-hosts" not in item.options and "-null" not in item.options)
 
     - name: Cleanup autofs file that should not exist
       ansible.builtin.file:

--- a/templates/template.autofs.j2
+++ b/templates/template.autofs.j2
@@ -1,2 +1,2 @@
 {{ ansible_managed | comment }}
-{{ item.mountpoint }} /etc/auto.{{ item.name | default(item.mountpoint) | regex_replace('^/', '') | regex_replace('/', autofs_slash_replace_char) }} {% if item.options is defined %}{% for option in item.options %}{{ option }}{% if not loop.last %} {% endif %}{% endfor %} {% endif %}
+{{ item.mountpoint }}{% if item.options is defined and ("-hosts" not in item.options and "-null" not in item.options) %} /etc/auto.{{ item.name | default(item.mountpoint) | regex_replace('^/', '') | regex_replace('/', autofs_slash_replace_char) }}{% endif %} {% if item.options is defined %}{% for option in item.options %}{{ option }}{% if not loop.last %} {% endif %}{% endfor %} {% endif %}


### PR DESCRIPTION
I thought I would have a go at adding the feature that I needed. (see #12 )

This allows you to utilise the builtin maps (`-hosts` and `-null`) provided by autofs. e.g.:
```
autofs_maps:
  - name: home-nfs
    mountpoint: /nfs
    options:
      - "-hosts"
      - browse
      - "--timeout=300"
      - "--negative-timeout=30"
```

The role now checks if `-hosts` or `-null` is included in the `options` array. If it is then it does not create the map file and you do not need to define `directories`.

I'm unfamiliar with molecule and encountered some errors getting it running - I'd appreciate pointers for adding suitable tests to this PR.

Thanks!
