### PR TITLE
Access facts via `ansible_facts` namespace

### DIFF
--- a/.cursor/rules/ansible.mdc
+++ b/.cursor/rules/ansible.mdc
@@ -45,7 +45,7 @@ alwaysApply: true
       Suse:
         - foobar
 
-    xyz_packages: "{{ _xyz_packages[ansible_os_family] | default(_xyz_packages['default']) }}"
+    xyz_packages: "{{ _xyz_packages[ansible_facts.os_family] | default(_xyz_packages['default']) }}"
     ```
 
     This pattern can be used for all kinds of things, such as:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,7 +6,7 @@ _autofs_requirements:
   Debian:
     - procps
 
-autofs_requirements: "{{ _autofs_requirements[ansible_os_family] | default(_autofs_requirements['default']) }}"
+autofs_requirements: "{{ _autofs_requirements[ansible_facts.os_family] | default(_autofs_requirements['default']) }}"
 
 autofs_packages:
   - autofs


### PR DESCRIPTION
This resolves warnings when running with ansible-core >=2.20.

It also resolves breakage for users who've set `INJECT_FACTS_AS_VARS=False`, as recommended since 2.20.